### PR TITLE
Fix pings comparison

### DIFF
--- a/test-datacenter.sh
+++ b/test-datacenter.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 bold=$(tput bold)
 normal=$(tput sgr0)
 
@@ -11,7 +13,7 @@ do
 	echo -n "Ping ${bold}${line}${normal}: "
 	ping_avg=`ping -c $1 $line | tail -n1 | cut -d'=' -f2 | cut -d'/' -f2`
 	echo "$ping_avg ms"
-	if [[ $ping_avg < $better_ping ]];
+	if [ $(bc <<< "$ping_avg < $better_ping") -eq 1 ];
 	then
 		better_ping=$ping_avg
 		better_datacenter=$line


### PR DESCRIPTION
Hi!

`<` is not correct condition operator for compare floats, use `bc` or `awk` for this. 

Before

```
$ ./test-datacenter.sh 1 datacenters.txt
-n Ping speedtest-lon1.digitalocean.com:
41.044 ms
-n Ping speedtest-sfo1.digitalocean.com:
187.708 ms
-n Ping speedtest-ams1.digitalocean.com:
34.413 ms
-n Ping speedtest-ams2.digitalocean.com:
33.094 ms
-n Ping speedtest-ams3.digitalocean.com:
34.866 ms
-n Ping speedtest-nyc1.digitalocean.com:
120.456 ms
-n Ping speedtest-nyc2.digitalocean.com:
116.714 ms
-n Ping speedtest-nyc3.digitalocean.com:
109.901 ms
-n Ping speedtest-sgp1.digitalocean.com:
249.764 ms
-n Ping speedtest-fra1.digitalocean.com:
36.559 ms
-n Ping speedtest-tor1.digitalocean.com:
140.873 ms
-n Ping speedtest-blr1.digitalocean.com:
209.207 ms

---------------------- Better Datacenter is -----------------------------------
Domain: speedtest-nyc3.digitalocean.com
Ping AVG: 109.901 ms
Name: nyc3
-------------------------------------------------------------------------------
```

After

```
$ ./test-datacenter.sh 1 datacenters.txt
-n Ping speedtest-lon1.digitalocean.com:
40.975 ms
-n Ping speedtest-sfo1.digitalocean.com:
185.113 ms
-n Ping speedtest-ams1.digitalocean.com:
34.236 ms
-n Ping speedtest-ams2.digitalocean.com:
33.202 ms
-n Ping speedtest-ams3.digitalocean.com:
34.690 ms
-n Ping speedtest-nyc1.digitalocean.com:
118.647 ms
-n Ping speedtest-nyc2.digitalocean.com:
116.403 ms
-n Ping speedtest-nyc3.digitalocean.com:
110.179 ms
-n Ping speedtest-sgp1.digitalocean.com:
251.406 ms
-n Ping speedtest-fra1.digitalocean.com:
36.528 ms
-n Ping speedtest-tor1.digitalocean.com:
138.720 ms
-n Ping speedtest-blr1.digitalocean.com:
209.215 ms

---------------------- Better Datacenter is -----------------------------------
Domain: speedtest-ams2.digitalocean.com
Ping AVG: 33.202 ms
Name: ams2
-------------------------------------------------------------------------------
```

Thanks.
